### PR TITLE
Organize manager checklist by day of week

### DIFF
--- a/.github/ISSUE_TEMPLATE/team-manager-duties.md
+++ b/.github/ISSUE_TEMPLATE/team-manager-duties.md
@@ -7,12 +7,27 @@ assignees: ''
 
 ---
 
+## Monday
+
 - [ ] Reschedule any team ceremonies that have conflicts
-- [ ] Lead the planning session
-- [ ] Confirm collaboration time agenda per the Slack thread or cancel collaboration time (Wednesday)
-- [ ] Lead retro (Thursday) OR
-- [ ] Ensure the agenda for the demo exists and is shared (Thursday)
 - [ ] Assign note-taker and timelord roles at large team meetings for the week
-- [ ] Write the first draft of the Weekly Ship (Thursday)
-- [ ] Ship the Weekly Ship (Friday)
+- [ ] Lead the planning session
+- [ ] Move notes/issues from the discovery board to the delivery board as needed
+
+## Wednesday
+
+- [ ] Confirm collaboration time agenda per the Slack thread or cancel collaboration time (Wednesday)
+
+## Thursday
+
+- [ ] Lead retro OR
+- [ ] Ensure the agenda for the demo exists and is shared
+- [ ] Write the first draft of the Weekly Ship
+
+## Friday
+
+- [ ] Ship the Weekly Ship
+- [ ] Archive any Github notes and issues that are completely finished
 - [ ] Pass the torch to the next Team Manager
+
+[Team Manager Schedule](https://docs.google.com/spreadsheets/d/1eMvXJyxjq4Cf2j1OEpD66DcJvPH97g-XSqHda0Irl0c/edit#gid=0)

--- a/.github/ISSUE_TEMPLATE/team-manager-duties.md
+++ b/.github/ISSUE_TEMPLATE/team-manager-duties.md
@@ -16,7 +16,7 @@ assignees: ''
 
 ## Wednesday
 
-- [ ] Confirm collaboration time agenda per the Slack thread or cancel collaboration time (Wednesday)
+- [ ] Confirm collaboration time agenda per the Slack thread or cancel collaboration time
 
 ## Thursday
 


### PR DESCRIPTION
* Breaks up the checklist by the date things should be done by.
* Adds a couple of new tasks
* Adds link to the team manager rotation